### PR TITLE
add Github workflows to build APT package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    target-branch: main
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      "pip":
+        patterns:
+          - "*"

--- a/.github/workflows/build-release-latest.yaml
+++ b/.github/workflows/build-release-latest.yaml
@@ -2,7 +2,6 @@ name: Build and release latest APT package
 
 on:
   workflow_dispatch:
-  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/build-release-latest.yaml
+++ b/.github/workflows/build-release-latest.yaml
@@ -1,0 +1,36 @@
+name: Build and release latest APT package
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: package APT
+    runs-on: [self-hosted, linux, X64]
+    container:
+        image: starwitorg/debian-packaging:0.0.2
+        env:
+          PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD_FLAT }}
+          GPG_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY_B64 }}          
+        volumes:
+            - ./:/code
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: build package
+        run: |
+            export PATH=/root/.local/bin/:$PATH
+            bash -c ./start_make.sh
+            echo "VERSION=$(poetry version -s)" >> $GITHUB_ENV
+            echo "Done building APT package"
+      - name: create release
+        run: |
+          cd /code
+          echo "Releasing package with version ${VERSION}"
+          gh release create ${VERSION} --title "${VERSION}" ./target/*deb ./target/*.dsc
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-release-latest.yaml
+++ b/.github/workflows/build-release-latest.yaml
@@ -2,6 +2,7 @@ name: Build and release latest APT package
 
 on:
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -2,7 +2,7 @@ name: PR build
 
 on:
   workflow_dispatch:
-  #pull_request:
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -1,0 +1,36 @@
+name: PR build
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: package APT
+    runs-on: [self-hosted, linux, X64]
+    container:
+        image: starwitorg/debian-packaging:0.0.2
+        env:
+          PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD_FLAT }}
+          GPG_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY_B64 }}          
+        volumes:
+            - ./:/code
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: build apt package
+        run: |
+            echo "Build APT package"
+            export PATH=/root/.local/bin/:$PATH
+            bash -c ./start_make.sh
+            echo "VERSION=$(poetry version -s)" >> $GITHUB_ENV
+            echo "Finish building APT package"
+      - name: test poetry builds
+        run: |
+            export PATH=/root/.local/bin/:$PATH
+            #poetry install
+            #poetry build

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -2,7 +2,7 @@ name: PR build
 
 on:
   workflow_dispatch:
-  pull_request:
+  #pull_request:
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ cache
 *.pt
 .vscode
 *.yaml
+!.github/workflows/*.yaml
 !settings.template.yaml
 target
 dist
 debian/geomapper*
+env.sh

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,16 @@ check-settings:
 	./check_settings.sh
 
 build-deb: check-settings
-	dpkg-buildpackage -us -uc
+	$(shell echo ${GPG_KEY} | base64 --decode | gpg --batch --import)
+	$(eval KEYID := $(shell gpg --list-keys --with-colons | grep pub | cut -d: -f5))
+	@echo "Signing with key id: $(KEYID)"
+
+	@echo "Build package"
+	dpkg-buildpackage --no-sign
+	
+	@echo "Signing package"
+	$(shell echo "${PASSPHRASE}" | debsign -k$(KEYID) -p"gpg --batch --pinentry-mode loopback --passphrase-fd 0" ../${PACKAGE_NAME}_*.changes)	
+
 	mkdir -p target
 	mv ../${PACKAGE_NAME}_* target/
 

--- a/start_make.sh
+++ b/start_make.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Purpose of this script is to enforce a bash environment when calling make
+export PATH=/root/.local/bin/:$PATH
+cd /code
+
+make build-deb
+


### PR DESCRIPTION
APT packages will now be build via Github workflow

## Motivation and Context
No manual package build.

## How has this been tested?
Github

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
